### PR TITLE
vfio: fix compatability with older kernels (4.19)

### DIFF
--- a/include/villas/kernel/vfio_container.hpp
+++ b/include/villas/kernel/vfio_container.hpp
@@ -24,7 +24,14 @@ namespace villas {
 namespace kernel {
 namespace vfio {
 
+// Backwards compatability with older kernels
+#ifdef VFIO_UPDATE_VADDR
 static constexpr size_t EXTENSION_SIZE = VFIO_UPDATE_VADDR+1;
+#elif defined(VFIO_UNMAP_ALL)
+static constexpr size_t EXTENSION_SIZE = VFIO_UNMAP_ALL+1;
+#else
+static constexpr size_t EXTENSION_SIZE = VFIO_NOIOMMU_IOMMU+1;
+#endif
 
 class Container {
 public:

--- a/lib/kernel/vfio_container.cpp
+++ b/lib/kernel/vfio_container.cpp
@@ -52,8 +52,13 @@ static std::array<std::string, EXTENSION_SIZE> construct_vfio_extension_str() {
 	ret[VFIO_TYPE1_NESTING_IOMMU] = "Type 1 Nesting";
 	ret[VFIO_SPAPR_TCE_v2_IOMMU] = "SPAPR TCE v2";
 	ret[VFIO_NOIOMMU_IOMMU] = "No IOMMU";
+// Backwards compatability with older kernels
+#ifdef VFIO_UNMAP_ALL
 	ret[VFIO_UNMAP_ALL] = "Unmap all";
+#endif
+#ifdef VFIO_UPDATE_VADDR
 	ret[VFIO_UPDATE_VADDR] = "Update vaddr";
+#endif
 	return ret;
 }
 

--- a/lib/kernel/vfio_device.cpp
+++ b/lib/kernel/vfio_device.cpp
@@ -79,8 +79,8 @@ Device::Device(const std::string &name, int groupFileDescriptor, const kernel::p
 	if (ret < 0)
 		throw RuntimeError("Failed to get VFIO device info for: {}", name);
 
-	log->debug("device info: flags: 0x{:x}, num_regions: {}, num_irqs: {}, cap_offset: 0x{:x}",
-		info.flags, info.num_regions, info.num_irqs, info.cap_offset);
+	log->debug("device info: flags: 0x{:x}, num_regions: {}, num_irqs: {}",
+		info.flags, info.num_regions, info.num_irqs);
 
 	// device_info.num_region reports always 9 and includes a VGA region, which is only supported on
 	// certain device IDs. So for non-VGA devices VFIO_PCI_CONFIG_REGION_INDEX will be the highest
@@ -109,7 +109,6 @@ Device::Device(const std::string &name, int groupFileDescriptor, const kernel::p
 
 		regions[i] = region;
 	}
-
 
 	// Get device IRQs
 	for (size_t i = 0; i < info.num_irqs; i++) {


### PR DESCRIPTION
as they can be found on OPAL RT-Linux targets