### PR TITLE
Kernel module loading system and bug fixes of vfio

### DIFF
--- a/include/villas/kernel/vfio.hpp
+++ b/include/villas/kernel/vfio.hpp
@@ -1,8 +1,8 @@
 /** VFIO Kernel module loader
  *
  * Author: Pascal Bauer <pascal.bauer@rwth-aachen.de>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power
- * Systems, EONERC SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
+ * SPDX-License-Identifier: Apache-2.0
  *********************************************************************************/
 
 //TODO: Move to cmake args

--- a/include/villas/kernel/vfio.hpp
+++ b/include/villas/kernel/vfio.hpp
@@ -4,7 +4,6 @@
 
 #if defined(FPGA_PLATFORM)
     #define KERNEL_MODULE_VFIO
-    #define KERNEL_MODULE_VFIO_IOMMU_TYPE1
 #endif
 
 #if defined(FPGA_PCI)

--- a/include/villas/kernel/vfio.hpp
+++ b/include/villas/kernel/vfio.hpp
@@ -1,6 +1,6 @@
 //TODO: Move to cmake args
-#define FPGA_PLATFORM
-//#define FPGA_PCI
+//#define FPGA_PLATFORM
+#define FPGA_PCI
 
 #if defined(FPGA_PLATFORM)
     #define KERNEL_MODULE_VFIO

--- a/include/villas/kernel/vfio.hpp
+++ b/include/villas/kernel/vfio.hpp
@@ -1,3 +1,10 @@
+/** VFIO Kernel module loader
+ *
+ * Author: Pascal Bauer <pascal.bauer@rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power
+ * Systems, EONERC SPDX-License-Identifier: Apache-2.0
+ *********************************************************************************/
+
 //TODO: Move to cmake args
 //#define FPGA_PLATFORM
 #define FPGA_PCI

--- a/include/villas/kernel/vfio.hpp
+++ b/include/villas/kernel/vfio.hpp
@@ -1,0 +1,28 @@
+//TODO: Move to cmake args
+#define FPGA_PLATFORM
+//#define FPGA_PCI
+
+#if defined(FPGA_PLATFORM)
+    #define KERNEL_MODULE_VFIO
+    #define KERNEL_MODULE_VFIO_IOMMU_TYPE1
+#endif
+
+#if defined(FPGA_PCI)
+    #define KERNEL_MODULE_VFIO
+    #define KERNEL_MODULE_VFIO_PCI
+    #define KERNEL_MODULE_VFIO_IOMMU_TYPE1
+#endif
+
+static constexpr const char* const requiredKernelModules[] = {
+    #if defined(KERNEL_MODULE_VFIO)
+    "vfio",
+    #endif // KERNEL_MODULE_VFIO_PCI
+
+    #if defined(KERNEL_MODULE_VFIO_PCI)
+    "vfio_pci",
+    #endif // KERNEL_MODULE_VFIO_PCI
+    
+    #if defined(KERNEL_MODULE_VFIO_IOMMU_TYPE1)
+    "vfio_iommu_type1"
+    #endif // KERNEL_MODULE_VFIO_IOMMU_TYPE1
+};

--- a/include/villas/kernel/vfio.hpp
+++ b/include/villas/kernel/vfio.hpp
@@ -20,15 +20,15 @@
 #endif
 
 static constexpr const char* const requiredKernelModules[] = {
-    #if defined(KERNEL_MODULE_VFIO)
+#if defined(KERNEL_MODULE_VFIO)
     "vfio",
-    #endif // KERNEL_MODULE_VFIO_PCI
+#endif // KERNEL_MODULE_VFIO_PCI
 
-    #if defined(KERNEL_MODULE_VFIO_PCI)
+#if defined(KERNEL_MODULE_VFIO_PCI)
     "vfio_pci",
-    #endif // KERNEL_MODULE_VFIO_PCI
+#endif // KERNEL_MODULE_VFIO_PCI
     
-    #if defined(KERNEL_MODULE_VFIO_IOMMU_TYPE1)
+#if defined(KERNEL_MODULE_VFIO_IOMMU_TYPE1)
     "vfio_iommu_type1"
-    #endif // KERNEL_MODULE_VFIO_IOMMU_TYPE1
+#endif // KERNEL_MODULE_VFIO_IOMMU_TYPE1
 };

--- a/include/villas/kernel/vfio_device.hpp
+++ b/include/villas/kernel/vfio_device.hpp
@@ -37,6 +37,8 @@ public:
 
 	bool reset();
 
+	std::string get_name() { return name; };
+
 	// Map a device memory region to the application address space (e.g. PCI BARs)
 	void* regionMap(size_t index);
 

--- a/include/villas/kernel/vfio_device.hpp
+++ b/include/villas/kernel/vfio_device.hpp
@@ -37,7 +37,7 @@ public:
 
 	bool reset();
 
-	std::string get_name() { return name; };
+	std::string getName() { return name; };
 
 	// Map a device memory region to the application address space (e.g. PCI BARs)
 	void* regionMap(size_t index);

--- a/include/villas/memory_manager.hpp
+++ b/include/villas/memory_manager.hpp
@@ -120,6 +120,13 @@ private:
 			              << ", size=0x" << mapping.size
 			              << ")";
 		}
+
+		std::string str()
+		{
+			std::stringstream s;
+			s << *this;
+			return s.str();		
+		}
 	};
 
 	// Custom vertex in memory graph representing an address space

--- a/include/villas/memory_manager.hpp
+++ b/include/villas/memory_manager.hpp
@@ -121,7 +121,7 @@ private:
 			              << ")";
 		}
 
-		std::string str()
+		std::string toString()
 		{
 			std::stringstream s;
 			s << *this;

--- a/lib/kernel/vfio_container.cpp
+++ b/lib/kernel/vfio_container.cpp
@@ -41,8 +41,10 @@ using namespace villas::kernel::vfio;
   #define VFIO_NOIOMMU_IOMMU 8
 #endif
 
-static
-std::array<std::string, EXTENSION_SIZE> construct_vfio_extension_str() {
+// Uncomment to not load pci kernel modules
+#define LOAD_MODULE_PCI
+
+static std::array<std::string, EXTENSION_SIZE> construct_vfio_extension_str() {
 	std::array<std::string, EXTENSION_SIZE> ret;
 	ret[VFIO_TYPE1_IOMMU] = "Type 1";
 	ret[VFIO_SPAPR_TCE_IOMMU] = "SPAPR TCE";
@@ -74,9 +76,14 @@ Container::Container() :
 	groups(),
 	log(logging.get("kernel:vfio::Container"))
 {
-	static constexpr
-	const char* requiredKernelModules[] = {
-	    "vfio", "vfio_pci", "vfio_iommu_type1"
+	static constexpr const char* requiredKernelModules[] = {
+	    "vfio", 
+
+		#if !defined(LOAD_MODULE_PCI)
+		"vfio_pci",
+		#endif // LOAD_MODULE_PCI
+		
+		"vfio_iommu_type1"
 	};
 
 	for (const char* module : requiredKernelModules) {

--- a/lib/kernel/vfio_container.cpp
+++ b/lib/kernel/vfio_container.cpp
@@ -75,10 +75,7 @@ Container::Container() :
 	log(logging.get("kernel:vfio::Container"))
 {
 	for (const char* module : requiredKernelModules) {
-		if (kernel::loadModule(module) != 0) {
-			throw RuntimeError("Kernel module '{}' required but could not be loaded. "
-			              "Please load manually!", module);
-		}
+		kernel::loadModule(module);
 	}
 
 	// Create a VFIO Container

--- a/lib/kernel/vfio_container.cpp
+++ b/lib/kernel/vfio_container.cpp
@@ -32,6 +32,7 @@
 
 #include <villas/exceptions.hpp>
 #include <villas/log.hpp>
+#include <villas/kernel/vfio.hpp>
 #include <villas/kernel/vfio_container.hpp>
 #include <villas/kernel/kernel.hpp>
 
@@ -40,9 +41,6 @@ using namespace villas::kernel::vfio;
 #ifndef VFIO_NOIOMMU_IOMMU
   #define VFIO_NOIOMMU_IOMMU 8
 #endif
-
-// Uncomment to not load pci kernel modules
-#define LOAD_MODULE_PCI
 
 static std::array<std::string, EXTENSION_SIZE> construct_vfio_extension_str() {
 	std::array<std::string, EXTENSION_SIZE> ret;
@@ -76,16 +74,6 @@ Container::Container() :
 	groups(),
 	log(logging.get("kernel:vfio::Container"))
 {
-	static constexpr const char* requiredKernelModules[] = {
-	    "vfio", 
-
-		#if !defined(LOAD_MODULE_PCI)
-		"vfio_pci",
-		#endif // LOAD_MODULE_PCI
-		
-		"vfio_iommu_type1"
-	};
-
 	for (const char* module : requiredKernelModules) {
 		if (kernel::loadModule(module) != 0) {
 			throw RuntimeError("Kernel module '{}' required but could not be loaded. "

--- a/lib/kernel/vfio_container.cpp
+++ b/lib/kernel/vfio_container.cpp
@@ -42,7 +42,8 @@ using namespace villas::kernel::vfio;
   #define VFIO_NOIOMMU_IOMMU 8
 #endif
 
-static std::array<std::string, EXTENSION_SIZE> construct_vfio_extension_str() {
+static
+std::array<std::string, EXTENSION_SIZE> construct_vfio_extension_str() {
 	std::array<std::string, EXTENSION_SIZE> ret;
 	ret[VFIO_TYPE1_IOMMU] = "Type 1";
 	ret[VFIO_SPAPR_TCE_IOMMU] = "SPAPR TCE";

--- a/lib/kernel/vfio_container.cpp
+++ b/lib/kernel/vfio_container.cpp
@@ -75,7 +75,10 @@ Container::Container() :
 	log(logging.get("kernel:vfio::Container"))
 {
 	for (const char* module : requiredKernelModules) {
-		kernel::loadModule(module);
+		if (kernel::loadModule(module) != 0) {
+				throw RuntimeError("Kernel module '{}' required but could not be loaded. "
+						"Please load manually!", module);
+		}
 	}
 
 	// Create a VFIO Container

--- a/lib/kernel/vfio_device.cpp
+++ b/lib/kernel/vfio_device.cpp
@@ -84,7 +84,7 @@ Device::Device(const std::string &name, int groupFileDescriptor, const kernel::p
 	log->debug("device info: flags: 0x{:x}, num_regions: {}, num_irqs: {}",
 		info.flags, info.num_regions, info.num_irqs);
 
-	if (pci_device != 0){
+	if (pci_device != 0) {
 		// device_info.num_region reports always 9 and includes a VGA region, which is only supported on
 		// certain device IDs. So for non-VGA devices VFIO_PCI_CONFIG_REGION_INDEX will be the highest
 		// region index. This is the config space.

--- a/lib/kernel/vfio_device.cpp
+++ b/lib/kernel/vfio_device.cpp
@@ -30,8 +30,6 @@
 #include <villas/exceptions.hpp>
 #include <villas/kernel/vfio_device.hpp>
 
-#include <iostream>
-
 using namespace villas::kernel::vfio;
 
 static

--- a/lib/kernel/vfio_device.cpp
+++ b/lib/kernel/vfio_device.cpp
@@ -97,7 +97,7 @@ Device::Device(const std::string &name, int groupFileDescriptor, const kernel::p
 	mappings.resize(info.num_regions);
 
 	// Get device regions
-	for (size_t i = 0; i < info.num_regions && i < 8; i++) {
+	for (size_t i = 0; i < info.num_regions; i++) {
 		struct vfio_region_info region;
 		memset(&region, 0, sizeof (region));
 

--- a/lib/kernel/vfio_device.cpp
+++ b/lib/kernel/vfio_device.cpp
@@ -89,7 +89,7 @@ Device::Device(const std::string &name, int groupFileDescriptor, const kernel::p
 		// certain device IDs. So for non-VGA devices VFIO_PCI_CONFIG_REGION_INDEX will be the highest
 		// region index. This is the config space.
 		info.num_regions = VFIO_PCI_CONFIG_REGION_INDEX + 1;
-	}else{ info.num_regions = 1; }
+	} else { info.num_regions = 1; }
 
 	// Reserve slots already so that we can use the []-operator for access
 	irqs.resize(info.num_irqs);

--- a/lib/kernel/vfio_device.cpp
+++ b/lib/kernel/vfio_device.cpp
@@ -84,10 +84,12 @@ Device::Device(const std::string &name, int groupFileDescriptor, const kernel::p
 	log->debug("device info: flags: 0x{:x}, num_regions: {}, num_irqs: {}",
 		info.flags, info.num_regions, info.num_irqs);
 
-	// device_info.num_region reports always 9 and includes a VGA region, which is only supported on
-	// certain device IDs. So for non-VGA devices VFIO_PCI_CONFIG_REGION_INDEX will be the highest
-	// region index. This is the config space.
-	info.num_regions = VFIO_PCI_CONFIG_REGION_INDEX + 1;
+	if (pci_device != 0){
+		// device_info.num_region reports always 9 and includes a VGA region, which is only supported on
+		// certain device IDs. So for non-VGA devices VFIO_PCI_CONFIG_REGION_INDEX will be the highest
+		// region index. This is the config space.
+		info.num_regions = VFIO_PCI_CONFIG_REGION_INDEX + 1;
+	}
 
 	// Reserve slots already so that we can use the []-operator for access
 	irqs.resize(info.num_irqs);

--- a/lib/kernel/vfio_device.cpp
+++ b/lib/kernel/vfio_device.cpp
@@ -30,6 +30,8 @@
 #include <villas/exceptions.hpp>
 #include <villas/kernel/vfio_device.hpp>
 
+#include <iostream>
+
 using namespace villas::kernel::vfio;
 
 static
@@ -89,7 +91,7 @@ Device::Device(const std::string &name, int groupFileDescriptor, const kernel::p
 		// certain device IDs. So for non-VGA devices VFIO_PCI_CONFIG_REGION_INDEX will be the highest
 		// region index. This is the config space.
 		info.num_regions = VFIO_PCI_CONFIG_REGION_INDEX + 1;
-	}
+	}else{ info.num_regions = 1; }
 
 	// Reserve slots already so that we can use the []-operator for access
 	irqs.resize(info.num_irqs);
@@ -108,7 +110,7 @@ Device::Device(const std::string &name, int groupFileDescriptor, const kernel::p
 		if (ret < 0)
 			throw RuntimeError("Failed to get region {} of VFIO device: {}", i, name);
 
-        	log->debug("region {} info: flags: 0x{:x}, cap_offset: 0x{:x}, size: 0x{:x}, offset: 0x{:x}",
+		log->debug("region {} info: flags: 0x{:x}, cap_offset: 0x{:x}, size: 0x{:x}, offset: 0x{:x}",
                		region.index, region.flags, region.cap_offset, region.size, region.offset);
 
 		regions[i] = region;


### PR DESCRIPTION
Squash recomended before merge.
- feature: Header to specify which kernel modules (vfio support) to load
- Bug fixes: wrong errror messages, bugged region cap
- Quality of use improvements e.g. getter and str()